### PR TITLE
[NH] Prettify place names.

### DIFF
--- a/src/usps_processor/api.clj
+++ b/src/usps_processor/api.clj
@@ -1,13 +1,13 @@
 (ns usps-processor.api
   (:require [usps-processor.mailing :as mailing]
+            [usps-processor.zip-lookup :refer [zipcode->city-state]]
             [turbovote.datomic-toolbox :as d]
             [compojure.core :refer [defroutes GET]]
             [compojure.handler :refer [site]]
             [org.httpkit.server :refer [run-server]]
             [turbovote.resource-config :refer [config]]
             [clojure.set :as set]
-            [clojure.tools.logging :refer [info]]
-            [clojure.edn :as edn])
+            [clojure.tools.logging :refer [info]])
   (:gen-class))
 
 (def param->query-key
@@ -28,12 +28,6 @@
   {:status 200
    :headers {"Content-Type" "application/edn"}
    :body (pr-str body)})
-
-(def zipcode->city-state
-  (-> "zipcode-city-state.edn"
-      clojure.java.io/resource
-      slurp
-      edn/read-string))
 
 (defn attach-facility-city-state [scan]
   (assoc scan

--- a/src/usps_processor/zip_lookup.clj
+++ b/src/usps_processor/zip_lookup.clj
@@ -1,0 +1,23 @@
+(ns usps-processor.zip-lookup
+  (:require [clojure.edn :as edn]))
+
+(defn single-proper-case [s]
+  (if (#{"of" "in" "on"} (.toLowerCase s))
+    (.toLowerCase s)
+    (str (.toUpperCase (subs s 0 1))
+         (.toLowerCase (subs s 1)))))
+
+(defn proper-case [s]
+  (apply str
+         (map single-proper-case
+              (map (partial apply str)
+                   (partition-by #{\space \-} s)))))
+
+(def zipcode->city-state
+  (let [data (-> "zipcode-city-state.edn"
+                 clojure.java.io/resource
+                 slurp
+                 edn/read-string)]
+    (into {}
+          (for [[zip {:keys [city state]}] data]
+            [zip {:city (proper-case city) :state state}]))))

--- a/test/usps_processor/api_test.clj
+++ b/test/usps_processor/api_test.clj
@@ -21,9 +21,9 @@
     (let [scan {:scan/facility-zip "11215"}]
       (is (= (render-scan scan)
              {:scan/facility-zip "11215"
-              :scan/facility-city-state {:city "BROOKLYN" :state "NY"}}))))
+              :scan/facility-city-state {:city "Brooklyn" :state "NY"}}))))
   (testing "attaches the correct location for a 0-leading zipcode"
     (let [scan {:scan/facility-zip "06850"}]
       (is (= (render-scan scan)
              {:scan/facility-zip "06850"
-              :scan/facility-city-state {:city "NORWALK" :state "CT"}})))))
+              :scan/facility-city-state {:city "Norwalk" :state "CT"}})))))

--- a/test/usps_processor/zip_lookup_test.clj
+++ b/test/usps_processor/zip_lookup_test.clj
@@ -1,0 +1,9 @@
+(ns usps-processor.zip-lookup-test
+  (:require [clojure.test :refer :all]
+            [usps-processor.zip-lookup :refer :all]))
+
+(deftest proper-case-test
+  (testing "properly cases a place name"
+    (is (= "Brooklyn" (proper-case "BROOKLYN")))
+    (is (= "New York" (proper-case "NEW YORK")))
+    (is (= "Grand View-on-Hudson" (proper-case "GRAND VIEW-ON-HUDSON")))))


### PR DESCRIPTION
This is to make [this story](https://www.pivotaltracker.com/story/show/78496954) not have to worry about how to format a place name. It'll also make the ballot-scout dashboard prettier. I doubt this covers every imaginable place name in this country but it seems to cover most (check out the zipcode-city-state.edn for every possible place).
