### PR TITLE
[EN] Start importer in a daemon, api as web, in new main.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,6 +28,6 @@
   :repositories {"my.datomic.com" {:url "https://my.datomic.com/repo"
                                    :username :env
                                    :password :env}}
-  :main usps-processor.importer
+  :main usps-processor.core
   :aliases {"reset-db" ["run" "-m" "dev.db"]}
   :ring {:handler usps-processor.api/app})

--- a/src/usps_processor/core.clj
+++ b/src/usps_processor/core.clj
@@ -1,0 +1,35 @@
+(ns usps-processor.core
+  (:require [usps-processor.api :as api]
+            [usps-processor.importer :as importer]
+            [immutant.daemons :refer [singleton-daemon]]
+            [immutant.web :as web]
+            [clojure.tools.logging :refer [info]])
+  (:gen-class))
+
+(def messages-future (atom nil))
+(def api-server (atom nil))
+
+(defn start-importer []
+  (swap! messages-future (fn [mf]
+                           (when mf (future-cancel mf))
+                           (importer/-main))))
+
+(defn stop-importer []
+  (swap! messages-future #(when %
+                            (future-cancel %)
+                            nil)))
+
+(defn start-web-server []
+  (swap! api-server (fn [as]
+                      (when as (web/stop as))
+                      (api/-main))))
+
+(defn stop-web-server []
+  (swap! api-server #(when %
+                       (web/stop %))))
+
+(defn -main [& args]
+  (info "Starting immutant daemon for importer")
+  (singleton-daemon "usps-processor.importer" start-importer stop-importer)
+  (info "Starting api server")
+  (api/-main))

--- a/src/usps_processor/core.clj
+++ b/src/usps_processor/core.clj
@@ -25,6 +25,5 @@
   (info "Starting importer thread")
   (.start (Thread. start-importer))
   (immutant.util/at-exit stop-importer)
-  ;;(singleton-daemon "usps-processor.importer" start-importer stop-importer)
   (info "Starting api server")
   (api/-main))

--- a/src/usps_processor/core.clj
+++ b/src/usps_processor/core.clj
@@ -1,8 +1,8 @@
 (ns usps-processor.core
   (:require [usps-processor.api :as api]
             [usps-processor.importer :as importer]
-            [immutant.daemons :refer [singleton-daemon]]
             [immutant.web :as web]
+            [immutant.util]
             [clojure.tools.logging :refer [info]])
   (:gen-class))
 
@@ -22,7 +22,9 @@
                            nil)))
 
 (defn -main [& args]
-  (info "Starting immutant daemon for importer")
-  (singleton-daemon "usps-processor.importer" start-importer stop-importer)
+  (info "Starting importer thread")
+  (.start (Thread. start-importer))
+  (immutant.util/at-exit stop-importer)
+  ;;(singleton-daemon "usps-processor.importer" start-importer stop-importer)
   (info "Starting api server")
   (api/-main))

--- a/src/usps_processor/core.clj
+++ b/src/usps_processor/core.clj
@@ -12,21 +12,14 @@
 (defn start-importer []
   (swap! messages-future (fn [mf]
                            (when mf (future-cancel mf))
-                           (importer/-main))))
+                           (importer/-main) ;; returns a new future
+                           )))
 
 (defn stop-importer []
-  (swap! messages-future #(when %
-                            (future-cancel %)
-                            nil)))
-
-(defn start-web-server []
-  (swap! api-server (fn [as]
-                      (when as (web/stop as))
-                      (api/-main))))
-
-(defn stop-web-server []
-  (swap! api-server #(when %
-                       (web/stop %))))
+  (swap! messages-future (fn [mf]
+                           (when mf
+                             (future-cancel mf))
+                           nil)))
 
 (defn -main [& args]
   (info "Starting immutant daemon for importer")


### PR DESCRIPTION
This branch continues the migration from Immutant to Immutant 2.
The previous version ran `immutant.daemons/daemonize` with a :singleton?
false option. Unfortunately, Immutant 2 does not allow such an
option. It is always run as a singleton, which means that if run in a
wildfly cluster, at most one version will be running on the cluster at
the same time.

If we are not using a wildfly cluster, the point is moot and the
solution in this branch is satisfactory.

If we are using a wildfly cluster, we have to think about whether
running it as a singleton is reasonable, and if not, find a new
solution.

I have asked on IRC but I got no answer. Web searches turn up nothing.