### PR TITLE
[EN] Move :test -main out of its own, lonely directory.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
   :profiles {:dev {:resource-paths ["dev-resources"]
                    :source-paths ["dev-src"]}
              :test {:resource-paths ["test-resources"]
-                    :main usps-processor.core/test-main}
+                    :main usps-processor.core-test}
              :uberjar {:aot [usps-processor.importer
                              usps-processor.api]}
              :production {:resource-paths ["env-configs/usps-processor/production/resources"]}}

--- a/project.clj
+++ b/project.clj
@@ -25,8 +25,7 @@
   :profiles {:dev {:resource-paths ["dev-resources"]
                    :source-paths ["dev-src"]}
              :test {:resource-paths ["test-resources"]
-                    :source-paths ["test-src"]
-                    :main test.main}
+                    :main usps-processor.core/test-main}
              :uberjar {:aot [usps-processor.importer
                              usps-processor.api]}
              :production {:resource-paths ["env-configs/usps-processor/production/resources"]}}

--- a/src/usps_processor/core.clj
+++ b/src/usps_processor/core.clj
@@ -27,3 +27,6 @@
   (immutant.util/at-exit stop-importer)
   (info "Starting api server")
   (api/-main))
+
+(defn test-main [& args]
+  nil)

--- a/src/usps_processor/core.clj
+++ b/src/usps_processor/core.clj
@@ -27,6 +27,3 @@
   (immutant.util/at-exit stop-importer)
   (info "Starting api server")
   (api/-main))
-
-(defn test-main [& args]
-  nil)

--- a/test-src/test/main.clj
+++ b/test-src/test/main.clj
@@ -1,4 +1,0 @@
-(ns test.main)
-
-(defn -main []
-  nil)

--- a/test/usps_processor/core_test.clj
+++ b/test/usps_processor/core_test.clj
@@ -1,0 +1,4 @@
+(ns usps-processor.core-test)
+
+(defn -main [& args]
+  nil)


### PR DESCRIPTION
This follows up on the immutant 2 migration. At that point, the :main directive was not properly working in the war. I filed a bug report and now it works. So there! Now we can delete a whole directory and a line from the project.clj that were cramping my ultra-modern, minimalist aesthetic.

Also, the testing inside of immutant has become simpler. The test profile is automatically included. Testing inside of immutant is now:

```
> lein immutant test -j path/to/wildfly
```
