### PR TITLE
Update datomic-toolbox & resource-config

### DIFF
--- a/dev-src/dev/db.clj
+++ b/dev-src/dev/db.clj
@@ -1,6 +1,6 @@
 (ns dev.db
-  (:require [turbovote.datomic-toolbox :as db]
-            democracyworks.squishy.data-readers
+  (:require [datomic-toolbox.core :as db]
+            [democracyworks.squishy.data-readers]
             [clojure.edn :as edn]
             [datomic.api :as d]
             [turbovote.resource-config :refer [config]]))
@@ -18,8 +18,11 @@
   (db/transact seed-tx-data))
 
 (defn reset-db! []
-  (d/delete-database (config :datomic :uri))
-  (db/initialize)
+  ;; TODO: This isn't really correct. In Datomic you shouldn't delete and
+  ;; re-create the same database. It's against the grain of Datomic's immutable
+  ;; nature. And it does actually cause unpredictable behavior.
+  (d/delete-database (config [:datomic :uri]))
+  (db/initialize (config [:datomic]))
   (seed-db))
 
 (defn -main []

--- a/project.clj
+++ b/project.clj
@@ -3,14 +3,16 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.slf4j/slf4j-simple "1.7.12"]
                  [turbovote.resource-config "0.1.4"]
-                 [democracyworks/datomic-toolbox "1.0.0" :exclusions [com.datomic/datomic-pro]]
-                 [com.datomic/datomic-pro "0.9.5130" :exclusions [org.slf4j/slf4j-nop]]
+                 [democracyworks/datomic-toolbox "2.0.1"
+                  :exclusions [com.datomic/datomic-pro]]
+                 [com.datomic/datomic-pro "0.9.5327"
+                  :exclusions [org.slf4j/slf4j-nop]]
                  [clj-aws-s3 "0.3.10"]
-                 [clj-time "0.9.0"]
+                 [clj-time "0.11.0"]
                  [democracyworks.squishy "1.0.0"]
                  [org.clojure/data.csv "0.1.2"]
                  [turbovote.imbarcode "0.1.5"

--- a/src/usps_processor/importer.clj
+++ b/src/usps_processor/importer.clj
@@ -6,18 +6,18 @@
             [democracyworks.squishy :as sqs]
             [clojure.tools.logging :refer [info]]
             [turbovote.resource-config :refer [config]]
-            [datomic-toolbox :as d]
+            [datomic-toolbox.core :as dt]
             [datomic.api :as datomic]
             [riemann.client :as riemann]
             [clojure.edn :as edn])
   (:gen-class))
 
 (def riemann-client
-  (memoize (fn [] (riemann/udp-client :host (config :riemann :host)
-                                      :port (config :riemann :port)))))
+  (memoize (fn [] (riemann/udp-client :host (config [:riemann :host])
+                                      :port (config [:riemann :port])))))
 
 (defn send-event [metric description]
-  (when (config :riemann :host)
+  (when (config [:riemann :host])
     (riemann/send-event (riemann-client)
                         {:service "usps-processor scans" :metric metric
                          :tags ["usps-processor"]
@@ -36,7 +36,7 @@
 
 (defn -main [& args]
   (info "Starting up...")
-  (d/initialize)
+  (dt/initialize (config [:datomic]))
   (queue/initialize)
   (let [messages-future (sqs/consume-messages (sqs/client) process-file)]
     (info "Started")

--- a/src/usps_processor/mailing.clj
+++ b/src/usps_processor/mailing.clj
@@ -1,12 +1,12 @@
 (ns usps-processor.mailing
-  (:require [datomic-toolbox :as d]
-            [datomic.api :as db]))
+  (:require [datomic-toolbox.core :as dt]
+            [datomic.api :as d]))
 
 (defn scan->mailing [scan]
   (->> scan
        :scan/mailing
        :db/id
-       (db/entity (d/db))))
+       (d/entity (dt/db))))
 
 (defn render [mailing]
   (-> mailing

--- a/src/usps_processor/queue.clj
+++ b/src/usps_processor/queue.clj
@@ -17,7 +17,7 @@
 
 (defn initialize
   []
-  (let [conn (rmq/connect (config :rabbit-mq :connection))
+  (let [conn (rmq/connect (config [:rabbit-mq :connection]))
         ch   (lch/open conn)]
     (reset! channel ch)
     (le/declare ch events-exchange "topic" {:durable true :auto-delete false})))

--- a/src/usps_processor/s3.clj
+++ b/src/usps_processor/s3.clj
@@ -4,6 +4,6 @@
             [turbovote.resource-config :refer [config]]))
 
 (defn reader-from-s3 [bucket key]
-  (-> (s3/get-object (config :aws :creds) bucket key)
+  (-> (s3/get-object (config [:aws :creds]) bucket key)
       :content
       io/reader))

--- a/test/usps_processor/queue_test.clj
+++ b/test/usps_processor/queue_test.clj
@@ -2,16 +2,17 @@
   (:require [usps-processor.queue :refer :all]
             [clojure.test :refer :all]
             [langohr.basic :as lb]
-            [datomic-toolbox :as datomic-tb]
-            [datomic.api :as datomic]
+            [datomic-toolbox.core :as dt]
+            [datomic.api :as d]
             [usps-processor.db :as db]
-            [turbovote.resource-config :refer [config]]
             [clojure.edn :as edn]))
 
 (defn with-fresh-db [f]
-  (datomic/delete-database (config :datomic :uri))
-  (datomic-tb/initialize)
-  (f))
+  (let [uri (str "datomic:mem://usps-processor-" (java.util.UUID/randomUUID))]
+    (try
+      (dt/initialize {:uri uri, :partition :usps-processor})
+      (f)
+      (finally (d/delete-database uri)))))
 
 (def test-queue (atom []))
 


### PR DESCRIPTION
...and some other deps, including Clojure to 1.8.0.

Mostly motivated by the performance improvement in datomic-toolbox 2.0.1 (specifically it doesn't call `datomic.api/connect` on every transaction anymore).