### PR TITLE
No double EDN render

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,12 +6,14 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.clojure/core.async "0.2.385"]
-                 [org.slf4j/slf4j-simple "1.7.21"]
+                 [ch.qos.logback/logback-classic "1.1.7"]
                  [turbovote.resource-config "0.2.0"]
                  [democracyworks/datomic-toolbox "2.0.1"
                   :exclusions [com.datomic/datomic-pro]]
                  [com.datomic/datomic-pro "0.9.5385"
-                  :exclusions [org.slf4j/slf4j-nop commons-codec
+                  :exclusions [org.slf4j/slf4j-nop
+                               org.slf4j/slf4j-log4j12
+                               commons-codec
                                org.jboss.logging/jboss-logging]]
                  [com.amazonaws/aws-java-sdk "1.11.6"
                   :exclusions [commons-codec commons-logging
@@ -23,7 +25,7 @@
                                com.fasterxml.jackson.core/jackson-annotations
                                com.amazonaws/aws-java-sdk]]
                  [clj-time "0.12.0"]
-                 [democracyworks/squishy "3.0.0"
+                 [democracyworks/squishy "3.0.1"
                   :exclusions [commons-codec]]
                  [org.clojure/data.csv "0.1.3"]
                  [turbovote.imbarcode "0.1.5"
@@ -49,4 +51,5 @@
              :dev-overrides {}
              :dev [:dev-common :dev-overrides]
              :test {:resource-paths ["test-resources"]
-                    :main usps-processor.core-test}})
+                    :main usps-processor.core-test
+                    :jvm-opts ["-Dlog-level=OFF"]}})

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+  <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} %-5level [%logger] \(%thread\) %message%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="datomic" level="${log-level:-WARN}"/>
+  <logger name="usps-processor" level="${log-level:-DEBUG}"/>
+
+  <root level="${log-level:-INFO}">
+    <appender-ref ref="Console"/>
+  </root>
+</configuration>

--- a/src/usps_processor/importer.clj
+++ b/src/usps_processor/importer.clj
@@ -18,10 +18,9 @@
   (let [mailing (mailing/scan->mailing scan)
         rendered-scan (scan/render-scan scan)
         rendered-mailing (mailing/render mailing)
-        event (merge rendered-scan rendered-mailing)
-        edn (pr-str event)]
-    (log/info "Publishing scan event to usps-scans topic: " edn)
-    (async/>!! channels/usps-scans-out edn)))
+        event (merge rendered-scan rendered-mailing)]
+    (log/debug "Publishing scan event to usps-scans topic:" (pr-str event))
+    (async/>!! channels/usps-scans-out event)))
 
 (defn publish-scans
   [scans]

--- a/test/usps_processor/importer_test.clj
+++ b/test/usps_processor/importer_test.clj
@@ -43,7 +43,7 @@
                       :mailing/serial-number-9 "789654321"}]
         (async/alt!!
           channels/usps-scans-out
-          ([v] (is (=  (-> v edn/read-string) expected)))
+          ([v] (is (= v expected)))
 
           (async/timeout 500)
           (throw (RuntimeException. "test failed")))))))


### PR DESCRIPTION
@gws caught this bug while prepping for integration testing incoming USPS scans. Looks like it came about because pre-kehaar, we needed to encode messages into EDN ourselves, but kehaar will do that for us. So this was getting double-encoded into EDN.

I also opportunistically migrated this to logback to make the test output less noisy, get rid of the Datomic noise in REPLs, and make it more like our other components.