### PR TITLE
Run as AOT-compiled uberjar in Docker & CoreOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/democracyworks/didor:latest
+FROM clojure:lein-2.7.1-alpine
 MAINTAINER Democracy Works, Inc. <dev@democracy.works>
 
 RUN mkdir -p /usps-processor
@@ -7,12 +7,16 @@ WORKDIR /usps-processor
 COPY profiles.clj /usps-processor/
 COPY project.clj /usps-processor/
 
-RUN lein deps
+ARG env=production
+ARG DATOMIC_USERNAME
+ARG DATOMIC_PASSWORD
+
+RUN lein with-profiles $env,datomic-repo deps
 
 COPY . /usps-processor
 
-RUN lein test
+RUN lein with-profiles $env,datomic-repo,test test
 
-RUN lein immutant war --name usps-processor --destination target
+RUN lein with-profiles $env,datomic-repo uberjar
 
-EXPOSE 8080
+CMD ["java", "-jar", "target/usps-processor.jar"]

--- a/project.clj
+++ b/project.clj
@@ -43,10 +43,9 @@
                  [democracyworks/phantom-zone "0.1.1"]]
   :plugins [[lein-immutant "2.1.0"]]
   :main ^:skip-aot usps-processor.core
-  :target-path "target/%s"
   :repositories {"my.datomic.com" {:url "https://my.datomic.com/repo"
-                                   :username :env
-                                   :password :env}}
+                                   :username :env/datomic_username
+                                   :password :env/datomic_password}}
   :uberjar-name "usps-processor.jar"
   :profiles {:uberjar {:aot :all}
              :dev-common {:resource-paths ["dev-resources"]

--- a/script/build
+++ b/script/build
@@ -24,10 +24,7 @@ if [[ -z $DOCKER_REPO ]]; then
 fi
 
 echo '--- building docker image'
-if [[ -n $DATOMIC_USERNAME && -n $DATOMIC_PASSWORD ]]; then
-  cat profiles.clj.sample | perl -pe 's/USERNAME/$ENV{"DATOMIC_USERNAME"}/' | \
-    perl -pe 's/PASSWORD/$ENV{"DATOMIC_PASSWORD"}/' > profiles.clj
-fi
+if [[ ! -e "profiles.clj" ]]; then echo '{}' > profiles.clj; fi
 
 if [[ -z $BUILDKITE_BRANCH ]]; then
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -46,7 +43,9 @@ IMAGE_TAG=${BRANCH}-$(git rev-parse --short ${COMMIT})
 IMAGE_NAME="${DOCKER_REPO}:${IMAGE_TAG}"
 
 echo "Building ${IMAGE_NAME}"
-docker build --pull -t ${IMAGE_NAME} .
+docker build --build-arg DATOMIC_USERNAME=$DATOMIC_USERNAME \
+             --build-arg DATOMIC_PASSWORD=$DATOMIC_PASSWORD \
+             --pull -t ${IMAGE_NAME} .
 
 if [[ $CI = "true" && $BUILDKITE_PULL_REQUEST = "false" ]]; then
   echo '--- pushing docker image to registry'

--- a/usps-processor@.service.template
+++ b/usps-processor@.service.template
@@ -1,19 +1,17 @@
 [Unit]
-Description=USPS Processor
+Description=usps-processor
 
 After=docker.service
 Requires=docker.service
 After=consul@%i.service
 Wants=consul@%i.service
-After=wildfly@%i.service
-Requires=wildfly@%i.service
 After=rabbitmq@%i.service
-Requires=rabbitmq@%i.service
 
 [Service]
 EnvironmentFile=/etc/environment
 TimeoutStartSec=10min
 TimeoutStopSec=10min
+Restart=on-failure
 
 Environment=DOCKER_REPO=
 Environment=VERSION=
@@ -25,18 +23,19 @@ ExecStartPre=-/usr/bin/docker rm ${CONTAINER}
 ExecStartPre=/bin/bash -c 'sleep 2 && curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/buildkite/dockercfg?raw -o /root/.dockercfg'
 ExecStartPre=/usr/bin/docker pull ${DOCKER_REPO}:${VERSION}
 
-ExecStart=/usr/bin/bash -c 'docker run --name ${CONTAINER} --restart=always \
-   --link wildfly:wildfly \
-   --link rabbitmq:rabbitmq \
-   --env AWS_ACCESS_KEY=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/usps-processor/aws/credentials/access-key?raw) \
-   --env AWS_SECRET_KEY=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/usps-processor/aws/credentials/secret-key?raw) \
-   --env USPS_SQS_REGION=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/usps-processor/sqs/region?raw) \
-   --env USPS_SQS_QUEUE=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/usps-processor/sqs/queue?raw) \
-   --env USPS_SQS_FAIL_QUEUE=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/usps-processor/sqs/fail-queue?raw) \
-   --env USPS_DATOMIC_URI=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/datomic/uri-root?raw)/usps-processor \
-   ${DOCKER_REPO}:${VERSION}'
+ExecStart=/usr/bin/bash -c 'docker run --name ${CONTAINER} \
+  --dns $COREOS_PRIVATE_IPV4 \
+  --env AWS_ACCESS_KEY=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/usps-processor/aws/credentials/access-key?raw) \
+  --env AWS_SECRET_KEY=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/usps-processor/aws/credentials/secret-key?raw) \
+  --env USPS_SQS_REGION=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/usps-processor/sqs/region?raw) \
+  --env USPS_SQS_QUEUE=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/usps-processor/sqs/queue?raw) \
+  --env USPS_SQS_FAIL_QUEUE=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/usps-processor/sqs/fail-queue?raw) \
+  --env USPS_DATOMIC_URI=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/datomic/uri-root?raw)/usps-processor \
+  --env RABBITMQ_PORT_5672_TCP_ADDR=rabbitmq.service.consul \
+  --env RABBITMQ_PORT_5672_TCP_PORT=5672 \
+  ${DOCKER_REPO}:${VERSION}'
 
 ExecStop=/usr/bin/docker stop ${CONTAINER}
 
 [X-Fleet]
-MachineOf=wildfly@%i.service
+MachineOf=consul@%i.service


### PR DESCRIPTION
Make this run without WildFly in the same way we did for TurboVote components.

Part of [this card](https://www.pivotaltracker.com/story/show/135538383)